### PR TITLE
joyent/mahi#14 want API for listing members of a role

### DIFF
--- a/lib/server/redislib.js
+++ b/lib/server/redislib.js
@@ -26,6 +26,7 @@ module.exports = {
     getAccountUuid: getAccountUuid,
     getUuid: getUuid,
     getRoles: getRoles,
+    getRoleMembers: getRoleMembers,
     generateLookup: generateLookup
 };
 
@@ -461,6 +462,45 @@ function generateLookup(opts, cb) {
                     approved: account.approved_for_provisioning,
                     login: account.login
                 };
+            });
+            cb(null, lookup);
+            return;
+        });
+    });
+}
+
+/**
+ * Gets information about the members of a role
+ */
+function getRoleMembers(opts, cb) {
+    assert.string(opts.uuid, 'uuid');
+    assert.object(opts.log, 'log');
+    assert.object(opts.redis, 'redis');
+
+    var log = opts.log;
+    var redis = opts.redis;
+
+    log.debug('getRoleMembers: entered');
+
+    var key = sprintf('/uuid/%s/roles', opts.uuid);
+    redis.smembers(key, function (err, members) {
+        vasync.forEachParallel({
+            func: function (uuid, parallelcb) {
+                getObject({
+                    uuid: uuid,
+                    log: log,
+                    redis: redis
+                }, parallelcb);
+            },
+            inputs: members
+        }, function (err, results) {
+            if (err) {
+                cb(err);
+                return;
+            }
+            var lookup = {};
+            results.successes.forEach(function (account) {
+                lookup[account.uuid] = account;
             });
             cb(null, lookup);
             return;

--- a/lib/server/server.js
+++ b/lib/server/server.js
@@ -181,6 +181,11 @@ function Server(opts) {
     }, [getAccountUuid, getAccount, getUserUuid, getUser, getRoles, sendAuth]);
 
     server.get({
+        name: 'getRoleMembers',
+        path: '/roles'
+    }, [getAccountUuid, getAccount, getRoleMembers, sendAuth]);
+
+    server.get({
         name: 'nameToUuid',
         path: '/uuids'
     }, [getUuid]);
@@ -401,6 +406,46 @@ function getRoles(req, res, next) {
         req.log.debug({roles: req.auth.roles}, 'getRoles: done');
         req.auth.roles = roles;
         next();
+    });
+}
+
+
+function getRoleMembers(req, res, next) {
+    var accountUuid = req.accountUuid || req.params.accountid;
+    var name = req.params.role || req.params.name;
+
+    lib.getUuid({
+        accountUuid: accountUuid,
+        name: name,
+        type: 'role',
+        log: req.log,
+        redis: req.redis
+    }, function gotUuid(err, uuid) {
+        if (err) {
+            if (err.name === 'ObjectDoesNotExistError') {
+                next();
+            } else {
+                next(err);
+            }
+            return;
+        }
+
+        lib.getRole({
+            uuid: uuid,
+            log: req.log,
+            redis: req.redis
+        }, function gotRoleInfo(err, roleInfo) {
+            req.auth.role = roleInfo;
+
+            lib.getRoleMembers({
+                uuid: uuid,
+                log: req.log,
+                redis: req.redis
+            }, function gotRoleMembers(err, roleMembers) {
+                req.auth.role.members = roleMembers;
+                next();
+            });
+        });
     });
 }
 


### PR DESCRIPTION
This has been running on production at UQ for the last few months (and sits behind our implementation of "administrator" role support for CMON)

There's no change to data ingest from UFDS and no requirement to rebuild the redis DB from the changelog after this change. It's purely a new API endpoint, so the risk to existing clients is very low.