### PR TITLE
MANTA-5511 Mahi should send the derived key back to manta-buckets-api

### DIFF
--- a/lib/server/server.js
+++ b/lib/server/server.js
@@ -838,7 +838,8 @@ function Server(opts) {
                 userUuid: result.user.uuid,
                 assumedRole: result.assumedRole,
                 principalUuid: result.principalUuid,
-                isTemporaryCredential: result.isTemporaryCredential
+                isTemporaryCredential: result.isTemporaryCredential,
+                signingKey: result.signingKey
             });
             next();
         });

--- a/lib/server/sigv4.js
+++ b/lib/server/sigv4.js
@@ -414,7 +414,10 @@ function calculateSignature(secretKey, dateStamp, region, service,
         var kRegion = hmac(kDate, region);
         var kService = hmac(kRegion, service);
         var kSigning = hmac(kService, 'aws4_request');
-        return (hmac(kSigning, stringToSign).toString('hex'));
+        return ({
+                signature: hmac(kSigning, stringToSign).toString('hex'),
+                signingKey: kSigning.toString('hex')
+        });
 }
 
 /**
@@ -616,17 +619,17 @@ function handleTemporaryCredential(authInfo, sessionToken, req, log, ufds, cb) {
                ' signature calculation details');
 
             // Calculate expected signature using temporary secret key
-            var expectedSignature = calculateSignature(secretKey,
-                                                       authInfo.dateStamp,
-                                                       authInfo.region,
-                                                       authInfo.service,
-                                                       stringToSign);
+            var sigResult = calculateSignature(secretKey,
+                                               authInfo.dateStamp,
+                                               authInfo.region,
+                                               authInfo.service,
+                                               stringToSign);
 
             // Verify signature matches
-            if (expectedSignature !== authInfo.signature) {
+            if (sigResult.signature !== authInfo.signature) {
                 log.warn({
                     accessKeyId: authInfo.accessKeyId,
-                    expectedSignature: expectedSignature,
+                    expectedSignature: sigResult.signature,
                     providedSignature: authInfo.signature
                 }, 'sigv4.handleTemporaryCredential:' +
                    ' signature mismatch for temporary credential');
@@ -645,7 +648,8 @@ function handleTemporaryCredential(authInfo, sessionToken, req, log, ufds, cb) {
                 isTemporaryCredential: true,
                 assumedRole: credData.assumedrole,
                 principalUuid: principalUuid,
-                credentialType: 'temporary'
+                credentialType: 'temporary',
+                signingKey: sigResult.signingKey
             };
 
             log.debug({
@@ -943,6 +947,15 @@ function verifySigV4(opts, cb) {
                     }, 'sigv4.verify: Successfully verified temporary' +
                               ' credential from Redis with JWT');
 
+                    // Derive signing key for chunk signature
+                    // verification
+                    var redisSigResult = calculateSignature(
+                        tempCredData.secretAccessKey,
+                        authInfo.dateStamp,
+                        authInfo.region,
+                        authInfo.service,
+                        'dummy');
+
                     // Return the credential info for signature verification
                     cb(null, {
                         accessKeyId: tempCredData.accessKeyId,
@@ -954,7 +967,8 @@ function verifySigV4(opts, cb) {
                         isTemporaryCredential: true,
                         assumedRole: tempCredData.assumedRole,
                         principalUuid: tempCredData.userUuid,
-                        expiration: tempCredData.expiration
+                        expiration: tempCredData.expiration,
+                        signingKey: redisSigResult.signingKey
                     });
                     return;
                 }
@@ -1125,14 +1139,14 @@ function verifySigV4(opts, cb) {
                             utils.hexdump(stringToSign));
 
                         // Calculate expected signature
-                        var expectedSignature = calculateSignature(
+                        var sigResult = calculateSignature(
                                 secretKey, authInfo.dateStamp, authInfo.region,
                                 authInfo.service, stringToSign);
 
                         // Compare signatures
-                        if (expectedSignature !== authInfo.signature) {
+                        if (sigResult.signature !== authInfo.signature) {
                                 log.debug({
-                                        expected: expectedSignature,
+                                        expected: sigResult.signature,
                                         received: authInfo.signature,
                                         stringToSign: stringToSign,
                                         canonicalRequest: canonicalRequest
@@ -1147,7 +1161,8 @@ function verifySigV4(opts, cb) {
                                 'SigV4 verification successful');
                         cb(null, {
                                 user: user,
-                                accessKeyId: authInfo.accessKeyId
+                                accessKeyId: authInfo.accessKeyId,
+                                signingKey: sigResult.signingKey
                         });
                         return;
                 });


### PR DESCRIPTION
When temporary  keys are used to perform operations that require AWS-CHUNKED encoding, validation per chunk is not
possible. 
This patch adds a derived signing key for Sigv4 authentication,  that allows clients like, manta-buckets-api to use that key to validate the encoded chunks.

 Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>


